### PR TITLE
Move state() out to starting point and pass as a parameter

### DIFF
--- a/src/birdnet/mod.rs
+++ b/src/birdnet/mod.rs
@@ -2,7 +2,7 @@ mod detections;
 
 use serde_json::Value;
 use crate::birdnet::detections::Envelope;
-use crate::state::state;
+use crate::state::{state, State};
 
 const BASE_URL: &str = "https://app.birdweather.com/api/v1/stations";
 
@@ -18,9 +18,9 @@ impl BirdNetClient {
         }
     }
 
-    pub async fn recent_detections(&self) -> Result<Vec<String>, anyhow::Error> {
+    pub async fn recent_detections(&self, state: &State) -> Result<Vec<String>, anyhow::Error> {
         let data: Envelope = reqwest::Client::new()
-            .get(format!("{}/{}/detections", BASE_URL, state().birdnet.token) )
+            .get(format!("{}/{}/detections", BASE_URL, &state.birdnet.token) )
             /*
             .query(&[
                 (

--- a/src/calendar/mod.rs
+++ b/src/calendar/mod.rs
@@ -1,4 +1,4 @@
-use crate::state::state;
+use crate::state::{state, State};
 use chrono::{NaiveDate};
 use regex::Regex;
 
@@ -9,12 +9,12 @@ impl CalendarClient {
         Self {}
     }
 
-    pub async fn events(&self) -> Result<Vec<Event>, anyhow::Error> {
-        let state = state().calendar;
+    pub async fn events(&self, state: &State) -> Result<Vec<Event>, anyhow::Error> {
+        let state = &state.calendar;
         let mut events: Vec<Event> = Vec::new();
 
         let parens = Regex::new( "\\(.*\\)")?;
-        for url in state.urls {
+        for url in &state.urls {
             let result = reqwest::Client::new().get(url).send().await?.text().await?;
 
             let bytes = &*result.into_bytes();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ use clap::{Args, Parser, Subcommand};
 use std::time::Duration;
 use chrono::{Local, Utc};
 use crate::birdnet::BirdNetClient;
+use crate::state::state;
 
 #[derive(Debug, Clone, Parser)]
 #[command(
@@ -78,8 +79,9 @@ pub struct ScreenCommand {}
 
 impl ScreenCommand {
     pub async fn run<P: Paint>(&self, paint: &mut P) -> Result<(), anyhow::Error> {
+        let state = state();
         let ds = DataSource::new();
-        let data = ds.get().await?;
+        let data = ds.get(&state).await?;
 
         let mut display = Display::new(paint);
         display.draw_data_screen(&data, Utc::now())?;
@@ -93,6 +95,7 @@ pub struct LoopCommand {}
 
 impl LoopCommand {
     pub async fn run<P: Paint>(&self, paint: &mut P) -> Result<(), anyhow::Error> {
+        let state = state();
         let mut display = Display::new(paint);
         let _ = display.draw_clear_screen();
 
@@ -105,7 +108,7 @@ impl LoopCommand {
 
         loop {
 
-            let data = ds.get().await?;
+            let data = ds.get(&state).await?;
             /*
             if let Some(prev_data) = &prev_data {
                 if *prev_data == data {
@@ -136,8 +139,9 @@ pub struct TestCommand;
 
 impl TestCommand {
     pub async fn run<P: Paint>(&self, paint: &mut P) -> Result<(), anyhow::Error> {
+        let state = state();
         let client = BirdNetClient::new();
-        client.recent_detections().await?;
+        client.recent_detections(&state).await?;
         Ok(())
     }
 }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -192,19 +192,11 @@ impl DataSource {
     }
 
     async fn get_daily_forecast(&self, state: &State) -> Result<Vec<DailyForecast>, anyhow::Error> {
-        if let Some(forecast) = self.accuweather_daily.get(&state).await? {
-            Ok(forecast)
-        } else {
-            Ok(vec![])
-        }
+        Ok(self.accuweather_daily.get(&state).await?.unwrap_or(vec![]))
     }
 
     async fn get_hourly_forecast(&self, state: &State) -> Result<Vec<HourlyForecast>, anyhow::Error> {
-        if let Some(forecast) = self.accuweather_hourly.get(&state).await? {
-            Ok(forecast)
-        } else {
-            Ok(vec![])
-        }
+        Ok(self.accuweather_hourly.get(&state).await?.unwrap_or(vec![]))
     }
 
     async fn get_now(&self, state: &State) -> Result<NowData, anyhow::Error> {

--- a/src/netatmo/mod.rs
+++ b/src/netatmo/mod.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
 use crate::netatmo::station_data::Envelope;
-use crate::state::{state, update_state};
+use crate::state::{state, State, update_state};
 use serde::Deserialize;
 use serde_json::Value;
 use crate::accuweather::daily_forecast::Snow;
@@ -19,8 +19,8 @@ pub struct RefreshedToken {
     refresh_token: String,
 }
 
-pub async fn get_client() -> Result<NetatmoClient, anyhow::Error> {
-    let state = state().netatmo;
+pub async fn get_client(state: &State) -> Result<NetatmoClient, anyhow::Error> {
+    let state = &state.netatmo;
 
     let client = reqwest::Client::new();
     let result = client

--- a/src/purple/mod.rs
+++ b/src/purple/mod.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use crate::accuweather::daily_forecast::Snow;
 use crate::purple::purple_data::Envelope;
-use crate::state::state;
+use crate::state::{state, State};
 
 mod purple_data;
 
@@ -14,14 +14,14 @@ impl PurpleClient {
         Self {}
     }
 
-    pub async fn get_aqi(&self) -> Result<Aqi, anyhow::Error> {
-        let state = state().purple;
+    pub async fn get_aqi(&self, state: &State) -> Result<Aqi, anyhow::Error> {
+        let state = &state.purple;
 
         let url = format!("{}/{}", GET_SENSOR_DATA_URL, state.sensor_index);
         let response = reqwest::Client::new()
             .get(url)
             .query(&[("fields", "pm2.5,pm2.5_60minute,pm2.5_6hour,pm2.5_24hour")])
-            .header("X-API-KEY", state.api_key)
+            .header("X-API-KEY", &state.api_key)
             .send()
             .await?;
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -51,7 +51,7 @@ static STATE: RwLock<Option<State>> = RwLock::new(None);
 
 pub fn state() -> State {
     if STATE.read().unwrap().is_none() {
-        let mut config = File::open("lattitude.toml").unwrap();
+        let mut config = File::open("lattitude.toml").expect("Missing lattitude.toml file!");
         let mut data = String::new();
         let _ = config.read_to_string(&mut data);
 


### PR DESCRIPTION
Note: Does this PR actually work?  I don't know. I am trying to refactor to get to optional data sources and have not connected to any actual data sources yet.  

Every model was calling state().  This means for each backend it was re-reading the toml file.  So one possible improvement is
that state() will only happen once.  The second possible improvement is if unit tests are added we can more easily stub out state.

The primary motivation though is to be able to mark all `State` fields as `Option<>`.  This in turn will allow serde to read in any fields just using the simple derive macros.  The next piece of this will be to replace DataSource with something which can accept 0-n CachedData for the stuff loaded into State.

I had considered changing all the modules (birdnet etc) to deal with Option<State> but it just cascades into a lot of complexity and changed code.  It also seems like if we want to handle no birdnet then it should happen outside of the model (e.g. the model should not get defined at all).