### PR TITLE
Make State load optional back end sources plus start not passing state everywhere

### DIFF
--- a/src/accuweather/hourly_forecast.rs
+++ b/src/accuweather/hourly_forecast.rs
@@ -1,7 +1,6 @@
 use std::hash::{Hash, Hasher};
 use chrono::{DateTime, Local};
 use serde::Deserialize;
-use crate::accuweather::daily_forecast::Snow;
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Envelope(pub Vec<HourlyForecast>);

--- a/src/birdnet/detections.rs
+++ b/src/birdnet/detections.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Envelope {

--- a/src/birdnet/mod.rs
+++ b/src/birdnet/mod.rs
@@ -1,8 +1,7 @@
 mod detections;
 
-use serde_json::Value;
 use crate::birdnet::detections::Envelope;
-use crate::state::{state, State};
+use crate::state::BirdNetState;
 
 const BASE_URL: &str = "https://app.birdweather.com/api/v1/stations";
 
@@ -18,9 +17,9 @@ impl BirdNetClient {
         }
     }
 
-    pub async fn recent_detections(&self, state: &State) -> Result<Vec<String>, anyhow::Error> {
+    pub async fn recent_detections(&self, birdnet: &BirdNetState) -> Result<Vec<String>, anyhow::Error> {
         let data: Envelope = reqwest::Client::new()
-            .get(format!("{}/{}/detections", BASE_URL, &state.birdnet.token) )
+            .get(format!("{}/{}/detections", BASE_URL, &birdnet.token) )
             /*
             .query(&[
                 (

--- a/src/birdnet/mod.rs
+++ b/src/birdnet/mod.rs
@@ -2,7 +2,7 @@ mod detections;
 
 use serde_json::Value;
 use crate::birdnet::detections::Envelope;
-use crate::state::state;
+use crate::state::{state, State};
 
 const BASE_URL: &str = "https://app.birdweather.com/api/v1/stations";
 
@@ -18,9 +18,9 @@ impl BirdNetClient {
         }
     }
 
-    pub async fn recent_detections(&self) -> Result<Vec<String>, anyhow::Error> {
+    pub async fn recent_detections(&self, state: &State) -> Result<Vec<String>, anyhow::Error> {
         let data: Envelope = reqwest::Client::new()
-            .get(format!("{}/{}/detections", BASE_URL, state().birdnet.token) )
+            .get(format!("{}/{}/detections", BASE_URL, &state.birdnet.token) )
             /*
             .query(&[
                 (

--- a/src/calendar/mod.rs
+++ b/src/calendar/mod.rs
@@ -1,4 +1,4 @@
-use crate::state::state;
+use crate::state::{state, State};
 use chrono::{NaiveDate};
 use regex::Regex;
 
@@ -9,12 +9,12 @@ impl CalendarClient {
         Self {}
     }
 
-    pub async fn events(&self) -> Result<Vec<Event>, anyhow::Error> {
-        let state = state().calendar;
+    pub async fn events(&self, state: &State) -> Result<Vec<Event>, anyhow::Error> {
+        let state = &state.calendar;
         let mut events: Vec<Event> = Vec::new();
 
         let parens = Regex::new( "\\(.*\\)")?;
-        for url in state.urls {
+        for url in &state.urls {
             let result = reqwest::Client::new().get(url).send().await?.text().await?;
 
             let bytes = &*result.into_bytes();

--- a/src/calendar/mod.rs
+++ b/src/calendar/mod.rs
@@ -1,4 +1,4 @@
-use crate::state::{state, State};
+use crate::state::CalendarState;
 use chrono::{NaiveDate};
 use regex::Regex;
 
@@ -9,12 +9,11 @@ impl CalendarClient {
         Self {}
     }
 
-    pub async fn events(&self, state: &State) -> Result<Vec<Event>, anyhow::Error> {
-        let state = &state.calendar;
+    pub async fn events(&self, calendar: &CalendarState) -> Result<Vec<Event>, anyhow::Error> {
         let mut events: Vec<Event> = Vec::new();
 
         let parens = Regex::new( "\\(.*\\)")?;
-        for url in &state.urls {
+        for url in &calendar.urls {
             let result = reqwest::Client::new().get(url).send().await?.text().await?;
 
             let bytes = &*result.into_bytes();

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ use clap::{Args, Parser, Subcommand};
 use std::time::Duration;
 use chrono::{Local, Utc};
 use crate::birdnet::BirdNetClient;
+use crate::state::state;
 
 #[derive(Debug, Clone, Parser)]
 #[command(
@@ -78,8 +79,9 @@ pub struct ScreenCommand {}
 
 impl ScreenCommand {
     pub async fn run<P: Paint>(&self, paint: &mut P) -> Result<(), anyhow::Error> {
+        let state = state();
         let ds = DataSource::new();
-        let data = ds.get().await?;
+        let data = ds.get(&state).await?;
 
         let mut display = Display::new(paint);
         display.draw_data_screen(&data, Utc::now())?;
@@ -93,6 +95,7 @@ pub struct LoopCommand {}
 
 impl LoopCommand {
     pub async fn run<P: Paint>(&self, paint: &mut P) -> Result<(), anyhow::Error> {
+        let state = state();
         let mut display = Display::new(paint);
         let _ = display.draw_clear_screen();
 
@@ -105,7 +108,7 @@ impl LoopCommand {
 
         loop {
 
-            let data = ds.get().await?;
+            let data = ds.get(&state).await?;
             /*
             if let Some(prev_data) = &prev_data {
                 if *prev_data == data {
@@ -136,8 +139,9 @@ pub struct TestCommand;
 
 impl TestCommand {
     pub async fn run<P: Paint>(&self, paint: &mut P) -> Result<(), anyhow::Error> {
+        let state = state();
         let client = BirdNetClient::new();
-        client.recent_detections().await?;
+        client.recent_detections(&state).await?;
         Ok(())
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,11 +1,9 @@
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use crate::data::DataSource;
 use crate::display::Display;
 use crate::paint::Paint;
 use clap::{Args, Parser, Subcommand};
 use std::time::Duration;
-use chrono::{Local, Utc};
+use chrono::Utc;
 use crate::birdnet::BirdNetClient;
 use crate::state::state;
 
@@ -80,7 +78,7 @@ pub struct ScreenCommand {}
 impl ScreenCommand {
     pub async fn run<P: Paint>(&self, paint: &mut P) -> Result<(), anyhow::Error> {
         let state = state();
-        let ds = DataSource::new();
+        let ds = DataSource::new(&state);
         let data = ds.get(&state).await?;
 
         let mut display = Display::new(paint);
@@ -102,7 +100,7 @@ impl LoopCommand {
         let mut display = Display::new(paint);
         let _ = display.draw_splash_screen();
 
-        let ds = DataSource::new();
+        let ds = DataSource::new(&state);
 
         let mut prev_data = None;
 
@@ -138,10 +136,11 @@ impl LoopCommand {
 pub struct TestCommand;
 
 impl TestCommand {
-    pub async fn run<P: Paint>(&self, paint: &mut P) -> Result<(), anyhow::Error> {
+    pub async fn run<P: Paint>(&self, _paint: &mut P) -> Result<(), anyhow::Error> {
         let state = state();
+        let birdnet = state.birdnet.as_ref().unwrap();
         let client = BirdNetClient::new();
-        client.recent_detections(&state).await?;
+        client.recent_detections(birdnet).await?;
         Ok(())
     }
 }

--- a/src/data/data.rs
+++ b/src/data/data.rs
@@ -3,16 +3,15 @@ use crate::accuweather::hourly_forecast::HourlyForecast;
 use crate::calendar::Event;
 use crate::netatmo::{Humidity, Pressure, Rain, Temperature, Wind};
 use crate::purple::Aqi;
-use chrono::{DateTime, Utc};
 
 #[derive(PartialEq)]
 pub struct DisplayData {
     //pub time: DateTime<Utc>,
-    pub now: NowData,
-    pub daily_forecast: Vec<DailyForecast>,
-    pub hourly_forecast: Vec<HourlyForecast>,
-    pub events: Vec<Event>,
-    pub birds: Vec<String>,
+    pub now: Option<NowData>,
+    pub daily_forecast: Option<Vec<DailyForecast>>,
+    pub hourly_forecast: Option<Vec<HourlyForecast>>,
+    pub events: Option<Vec<Event>>,
+    pub birds: Option<Vec<String>>,
 }
 
 #[derive(PartialEq)]

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -192,19 +192,11 @@ impl DataSource {
     }
 
     async fn get_daily_forecast(&self, state: &State) -> Result<Vec<DailyForecast>, anyhow::Error> {
-        if let Some(forecast) = self.accuweather_daily.get(&state).await? {
-            Ok(forecast)
-        } else {
-            Ok(vec![])
-        }
+        Ok(self.accuweather_daily.get(&state).await?.unwrap_or(vec![]))
     }
 
     async fn get_hourly_forecast(&self, state: &State) -> Result<Vec<HourlyForecast>, anyhow::Error> {
-        if let Some(forecast) = self.accuweather_hourly.get(&state).await? {
-            Ok(forecast)
-        } else {
-            Ok(vec![])
-        }
+        Ok(self.accuweather_hourly.get(&state).await?.unwrap_or(vec![]))
     }
 
     async fn get_now(&self, state: &State) -> Result<NowData, anyhow::Error> {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -10,22 +10,22 @@ use std::cell::{RefCell};
 use std::future::Future;
 use std::pin::Pin;
 use crate::birdnet::BirdNetClient;
-use crate::state::{state, State};
+use crate::state::{BirdNetState, State};
 
 #[allow(clippy::module_inception)]
 pub mod data;
 
-pub struct CachedData<T> {
+pub struct CachedData<T, U> {
     data: RefCell<Option<T>>,
     as_of: RefCell<Option<DateTime<Utc>>>,
-    fetch: Box<dyn Fn(&State) -> Pin<Box<dyn Future<Output = Result<T, anyhow::Error>>>>>,
+    fetch: Box<dyn Fn(U) -> Pin<Box<dyn Future<Output = Result<T, anyhow::Error>>>>>,
     cadence: Box<dyn Fn() -> Duration>,
 }
 
-impl<T: Clone> CachedData<T> {
-    pub async fn get(&self, state: &State) -> Result<Option<T>, anyhow::Error> {
+impl<T: Clone, U> CachedData<T, U> {
+    pub async fn get(&self, state: U) -> Result<Option<T>, anyhow::Error> {
         if self.needs_fetch() {
-            let data = (self.fetch)(&state).await.map(|inner| Some(inner))?;
+            let data = (self.fetch)(state).await.map(|inner| Some(inner))?;
             self.as_of.borrow_mut().replace(Utc::now());
             *self.data.borrow_mut() = data;
         }
@@ -48,24 +48,24 @@ impl<T: Clone> CachedData<T> {
 }
 
 pub struct DataSource {
-    calendar: CachedData<Vec<Event>>,
-    netatmo: CachedData<NetatmoData>,
-    purple: CachedData<Aqi>,
-    accuweather_daily: CachedData<Vec<DailyForecast>>,
-    accuweather_hourly: CachedData<Vec<HourlyForecast>>,
-    birdnet: CachedData<Vec<String>>,
+    calendar: Option<CachedData<Vec<Event>, State>>,
+    netatmo: Option<CachedData<NetatmoData, State>>,
+    purple: Option<CachedData<Aqi, State>>,
+    accuweather_daily: Option<CachedData<Vec<DailyForecast>, State>>,
+    accuweather_hourly: Option<CachedData<Vec<HourlyForecast>, State>>,
+    birdnet: Option<CachedData<Vec<String>, State>>,
 }
 
 fn birdnet_cadence() -> Duration {
     Duration::minutes(10)
 }
 
-fn fetch_birdnet(state: &State) -> Pin<Box<dyn Future<Output = Result<Vec<String>, anyhow::Error>>>> {
-    let state = state.clone();
+fn fetch_birdnet(state: State) -> Pin<Box<dyn Future<Output = Result<Vec<String>, anyhow::Error>>>> {
+    let birdnet = state.birdnet.unwrap().clone();
     Box::pin(async move {
         println!("fetch birdnet");
         let client = BirdNetClient::new();
-        let birds = client.recent_detections(&state).await?;
+        let birds = client.recent_detections(&birdnet).await?;
         Ok(birds)
     })
 }
@@ -74,12 +74,12 @@ fn calendar_cadence() -> Duration {
     Duration::days(1)
 }
 
-fn fetch_calendar(state: &State) -> Pin<Box<dyn Future<Output = Result<Vec<Event>, anyhow::Error>>>> {
-    let state = state.clone();
+fn fetch_calendar(state: State) -> Pin<Box<dyn Future<Output = Result<Vec<Event>, anyhow::Error>>>> {
+    let calendar = state.calendar.unwrap().clone();
     Box::pin(async move {
         println!("fetch calendar");
         let client = calendar::CalendarClient::new();
-        let events = client.events(&state).await?;
+        let events = client.events(&calendar).await?;
         Ok(events)
     })
 }
@@ -88,11 +88,11 @@ fn netatmo_cadence() -> Duration {
     Duration::minutes(15)
 }
 
-fn fetch_netatmo(state: &State) -> Pin<Box<dyn Future<Output = Result<NetatmoData, anyhow::Error>>>> {
-    let state = state.clone();
+fn fetch_netatmo(state: State) -> Pin<Box<dyn Future<Output = Result<NetatmoData, anyhow::Error>>>> {
+    let netatmo = state.netatmo.unwrap().clone();
     Box::pin(async move {
         println!("fetch netatmo");
-        let netatmo_client = netatmo::get_client(&state).await?;
+        let netatmo_client = netatmo::get_client(&netatmo).await?;
         let netatmo_data = netatmo_client.get_station_data().await?;
         Ok(netatmo_data)
     })
@@ -102,12 +102,12 @@ fn purple_cadence() -> Duration {
     Duration::hours(2)
 }
 
-fn fetch_purple(state: &State) -> Pin<Box<dyn Future<Output = Result<Aqi, anyhow::Error>>>> {
-    let state = state.clone();
+fn fetch_purple(state: State) -> Pin<Box<dyn Future<Output = Result<Aqi, anyhow::Error>>>> {
+    let purple = state.purple.unwrap().clone();
     Box::pin(async move {
         println!("fetch purple");
         let purple_client = purple::PurpleClient::new();
-        let aqi = purple_client.get_aqi(&state).await?;
+        let aqi = purple_client.get_aqi(&purple).await?;
         Ok(aqi)
     })
 }
@@ -116,87 +116,121 @@ pub fn accuweather_cadence() -> Duration {
     Duration::minutes(30)
 }
 
-fn fetch_accuweather_daily_forecast(state: &State
+fn fetch_accuweather_daily_forecast(state: State
 ) -> Pin<Box<dyn Future<Output = Result<Vec<DailyForecast>, anyhow::Error>>>> {
-    let state = state.clone();
+    let accuweather = state.accuweather.unwrap().clone();
+    let location = state.location.unwrap().clone();
     Box::pin(async move {
         println!("fetch accuweather");
         let client = accuweather::AccuWeatherClient::new();
-        let forecast = client.daily_forecast(&state).await?;
+        let location_key = client.get_location_key(&location, &accuweather).await?;
+        let forecast = client.daily_forecast(location_key, &accuweather).await?;
         Ok(forecast)
     })
 }
 
-fn fetch_accuweather_hourly_forecast(state: &State
+fn fetch_accuweather_hourly_forecast(state: State
 ) -> Pin<Box<dyn Future<Output = Result<Vec<HourlyForecast>, anyhow::Error>>>> {
-    let state = state.clone();
+    let accuweather = state.accuweather.unwrap().clone();
+    let location = state.location.unwrap().clone();
     Box::pin(async move {
         println!("fetch accuweather hourly");
         let client = accuweather::AccuWeatherClient::new();
-        let forecast = client.hourly_forecasts(&state).await?;
+        let location_key = client.get_location_key(&location, &accuweather).await?;
+        let forecast = client.hourly_forecasts(location_key, &accuweather).await?;
         Ok(forecast)
     })
 }
 
 impl DataSource {
-    pub fn new() -> Self {
+    pub fn new(state: &State) -> Self {
         Self {
-            birdnet: CachedData {
+            birdnet: state.birdnet.as_ref().map(|_| CachedData {
                 data: RefCell::new(None),
                 as_of: RefCell::new(None),
                 fetch: Box::new(fetch_birdnet),
                 cadence: Box::new(birdnet_cadence),
-            },
-            calendar: CachedData {
+            }),
+            calendar: state.calendar.as_ref().map(|_| CachedData {
                 data: RefCell::new(None),
                 as_of: RefCell::new(None),
                 fetch: Box::new(fetch_calendar),
                 cadence: Box::new(calendar_cadence),
-            },
-            netatmo: CachedData {
+            }),
+            netatmo: state.netatmo.as_ref().map(|_| CachedData {
                 data: RefCell::new(None),
                 as_of: RefCell::new(None),
                 fetch: Box::new(fetch_netatmo),
                 cadence: Box::new(netatmo_cadence),
-            },
-            purple: CachedData {
+            }),
+            purple:state.purple.as_ref().map(|_| CachedData {
                 data: RefCell::new(None),
                 as_of: RefCell::new(None),
                 fetch: Box::new(fetch_purple),
                 cadence: Box::new(purple_cadence),
-            },
-            accuweather_daily: CachedData {
+            }),
+            accuweather_daily: state.accuweather.as_ref().map(|_| CachedData {
                 data: RefCell::new(None),
                 as_of: RefCell::new(None),
                 fetch: Box::new(fetch_accuweather_daily_forecast),
                 cadence: Box::new(accuweather_cadence),
-            },
-            accuweather_hourly: CachedData {
+            }),
+            accuweather_hourly: state.accuweather.as_ref().map(|_| CachedData {
                 data: RefCell::new(None),
                 as_of: RefCell::new(None),
                 fetch: Box::new(fetch_accuweather_hourly_forecast),
                 cadence: Box::new(accuweather_cadence),
-            },
+            }),
         }
     }
 
     pub async fn get(&self, state: &State) -> Result<DisplayData, anyhow::Error> {
+        let now = if state.netatmo.is_some() {
+            Some(self.get_now(&state).await?)
+        } else {
+            None
+        };
+
+        let daily_forecast = if state.accuweather.is_some() {
+            Some(self.get_daily_forecast(&state).await?)
+        } else {
+            None
+        };
+
+        let hourly_forecast = if state.accuweather.is_some() {
+            Some(self.get_hourly_forecast(&state).await?)
+        } else {
+            None
+        };
+
+        let events = if state.calendar.is_some() {
+            Some(self.calendar.as_ref().unwrap().get(state.clone()).await?.unwrap_or(vec![]))
+        } else {
+            Some(vec![])
+        };
+
+        let birds = if state.birdnet.is_some() {
+            Some(self.birdnet.as_ref().unwrap().get(state.clone()).await?.unwrap_or(vec![]))
+        } else {
+            Some(vec![])
+        };
+
         Ok(DisplayData {
             //time: Utc::now(),
-            now: self.get_now(&state).await?,
-            daily_forecast: self.get_daily_forecast(&state).await?,
-            hourly_forecast: self.get_hourly_forecast(&state).await?,
-            events: self.calendar.get(&state).await?.unwrap_or(vec![]),
-            birds: self.birdnet.get(&state).await?.unwrap_or(vec![]),
+            now,
+            daily_forecast,
+            hourly_forecast,
+            events,
+            birds,
         })
     }
 
     async fn get_daily_forecast(&self, state: &State) -> Result<Vec<DailyForecast>, anyhow::Error> {
-        Ok(self.accuweather_daily.get(&state).await?.unwrap_or(vec![]))
+        Ok(self.accuweather_daily.as_ref().unwrap().get(state.clone()).await?.unwrap_or(vec![]))
     }
 
     async fn get_hourly_forecast(&self, state: &State) -> Result<Vec<HourlyForecast>, anyhow::Error> {
-        Ok(self.accuweather_hourly.get(&state).await?.unwrap_or(vec![]))
+        Ok(self.accuweather_hourly.as_ref().unwrap().get(state.clone()).await?.unwrap_or(vec![]))
     }
 
     async fn get_now(&self, state: &State) -> Result<NowData, anyhow::Error> {
@@ -209,16 +243,20 @@ impl DataSource {
             aqi: None,
         };
 
-        if let Some(netatmo) = self.netatmo.get(&state).await? {
-            now_data.temp = netatmo.outside_temp();
-            now_data.wind = netatmo.wind();
-            now_data.rain = netatmo.rain();
-            now_data.humidity = netatmo.humidity();
-            now_data.pressure = netatmo.pressure();
+        if state.netatmo.is_some() {
+            if let Some(netatmo) = self.netatmo.as_ref().unwrap().get(state.clone()).await? {
+                now_data.temp = netatmo.outside_temp();
+                now_data.wind = netatmo.wind();
+                now_data.rain = netatmo.rain();
+                now_data.humidity = netatmo.humidity();
+                now_data.pressure = netatmo.pressure();
+            }
         }
 
-        if let Ok(purple) = self.purple.get(&state).await {
-            now_data.aqi = purple
+        if state.purple.is_some() {
+            if let Ok(purple) = self.purple.as_ref().unwrap().get(state.clone()).await {
+                now_data.aqi = purple
+            }
         }
 
         Ok(now_data)

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -38,11 +38,7 @@ impl<T: Clone, U> CachedData<T, U> {
     pub fn needs_fetch(&self) -> bool {
         if let Some(as_of) = &*self.as_of.borrow() {
             let age = Utc::now() - as_of;
-            if age > (self.cadence)() {
-                true
-            } else {
-                false
-            }
+            age > (self.cadence)()
         } else {
             true
         }

--- a/src/netatmo/mod.rs
+++ b/src/netatmo/mod.rs
@@ -1,7 +1,7 @@
 #![allow(unused)]
 
 use crate::netatmo::station_data::Envelope;
-use crate::state::{state, update_state};
+use crate::state::{state, State, update_state};
 use serde::Deserialize;
 use serde_json::Value;
 use crate::accuweather::daily_forecast::Snow;
@@ -19,8 +19,8 @@ pub struct RefreshedToken {
     refresh_token: String,
 }
 
-pub async fn get_client() -> Result<NetatmoClient, anyhow::Error> {
-    let state = state().netatmo;
+pub async fn get_client(state: &State) -> Result<NetatmoClient, anyhow::Error> {
+    let state = &state.netatmo;
 
     let client = reqwest::Client::new();
     let result = client

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -1,6 +1,6 @@
 use crate::graphics::{Color, Graphics};
 use anyhow::Error;
-use embedded_graphics::pixelcolor::{BinaryColor, Gray4};
+use embedded_graphics::pixelcolor::BinaryColor;
 
 pub trait Paint {
     fn paint<const WIDTH: usize, const HEIGHT: usize>(

--- a/src/purple/mod.rs
+++ b/src/purple/mod.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use crate::accuweather::daily_forecast::Snow;
 use crate::purple::purple_data::Envelope;
-use crate::state::state;
+use crate::state::{state, State};
 
 mod purple_data;
 
@@ -14,14 +14,14 @@ impl PurpleClient {
         Self {}
     }
 
-    pub async fn get_aqi(&self) -> Result<Aqi, anyhow::Error> {
-        let state = state().purple;
+    pub async fn get_aqi(&self, state: &State) -> Result<Aqi, anyhow::Error> {
+        let state = &state.purple;
 
         let url = format!("{}/{}", GET_SENSOR_DATA_URL, state.sensor_index);
         let response = reqwest::Client::new()
             .get(url)
             .query(&[("fields", "pm2.5,pm2.5_60minute,pm2.5_6hour,pm2.5_24hour")])
-            .header("X-API-KEY", state.api_key)
+            .header("X-API-KEY", &state.api_key)
             .send()
             .await?;
 

--- a/src/purple/mod.rs
+++ b/src/purple/mod.rs
@@ -1,7 +1,5 @@
-use clap::Parser;
-use crate::accuweather::daily_forecast::Snow;
 use crate::purple::purple_data::Envelope;
-use crate::state::{state, State};
+use crate::state::PurpleState;
 
 mod purple_data;
 
@@ -14,14 +12,12 @@ impl PurpleClient {
         Self {}
     }
 
-    pub async fn get_aqi(&self, state: &State) -> Result<Aqi, anyhow::Error> {
-        let state = &state.purple;
-
-        let url = format!("{}/{}", GET_SENSOR_DATA_URL, state.sensor_index);
+    pub async fn get_aqi(&self, purple: &PurpleState) -> Result<Aqi, anyhow::Error> {
+        let url = format!("{}/{}", GET_SENSOR_DATA_URL, purple.sensor_index);
         let response = reqwest::Client::new()
             .get(url)
             .query(&[("fields", "pm2.5,pm2.5_60minute,pm2.5_6hour,pm2.5_24hour")])
-            .header("X-API-KEY", &state.api_key)
+            .header("X-API-KEY", &purple.api_key)
             .send()
             .await?;
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -51,7 +51,7 @@ static STATE: RwLock<Option<State>> = RwLock::new(None);
 
 pub fn state() -> State {
     if STATE.read().unwrap().is_none() {
-        let mut config = File::open("lattitude.toml").unwrap();
+        let mut config = File::open("lattitude.toml").expect("Missing lattitude.toml file!");
         let mut data = String::new();
         let _ = config.read_to_string(&mut data);
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -5,18 +5,24 @@ use std::sync::RwLock;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct State {
-    pub location: LocationState,
-    pub netatmo: NetatmoState,
-    pub purple: PurpleState,
-    pub accuweather: AccuWeatherState,
-    pub calendar: CalendarState,
-    pub birdnet: BirdNetState,
+    pub location: Option<LocationState>,
+    pub netatmo: Option<NetatmoState>,
+    pub purple: Option<PurpleState>,
+    pub accuweather: Option<AccuWeatherState>,
+    pub calendar: Option<CalendarState>,
+    pub birdnet: Option<BirdNetState>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct LocationState {
     pub lat: f64,
     pub lon: f64,
+}
+
+impl LocationState {
+    pub fn location_key(&self) -> String {
+        format!("{},{}", &self.lat, &self.lon)
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
Make `State` load optional back end sources plus start not passing state everywhere.

The main piece is that any back end data source is optional.  Right now I am only using accuweather; so I see time at
top of generated bmp along with the accuweather bits.  This was accomplished by making all `State` fields be Optioned.  Option + serde derive gives this benefit for free.

The second big change for `State` is that it is loaded only once and the passed around as a reference.  Lifetime woes led to
some cloning but who doesn't like clones?  I think this cloning probably could be reduced or eliminated (I thought about 'static but it looks horrible) but the cost here is pretty tiny if you consider it will be doing network API calls a few ns later.

The third change is that instead of passing State which then needs to unwrap around the new Option piece it will use a 
generified state_to_type translator.  This makes the actual fetch and get functions see the specific data they work with and it
is also shown in the definition of the CachedData type itself.

The strange pieces:

   - View stuff is entirely a punt as I think that is going to change so it is just simple option checks with if statements.
   - Ultimately I think `DataSource` should be a `Vec`.  It can just loop over what is in there and reference a View or whatnot.

This was a bit bigger than I anticipated but my Rust knowledge is probably a bit lacking :smile: